### PR TITLE
Symmetry `F` and `M` and not `L`

### DIFF
--- a/chapter9.md
+++ b/chapter9.md
@@ -641,7 +641,7 @@ X>     ```
 X> 
 X>     Render this L-system. _Note_: you will need to decrease the number of iterations of the production rules, since the size of the final sentence grows exponentially with the number of iterations.
 X> 
-X>     Now, notice the symmetry between `L` and `M` in the production rules. The two "move forward" instructions can be differentiated using a `Boolean` value using the following alphabet type:
+X>     Now, notice the symmetry between `F` and `M` in the production rules. The two "move forward" instructions can be differentiated using a `Boolean` value using the following alphabet type:
 X> 
 X>     ```haskell
 X>     data Alphabet = L | R | F Boolean


### PR DESCRIPTION
Updating the document to show that the symmetry is `F` and `M` and not `L` and `M`.